### PR TITLE
FFWEB-1604: added Recommendation push import type

### DIFF
--- a/src/Api/PushImport.php
+++ b/src/Api/PushImport.php
@@ -33,7 +33,7 @@ class PushImport
         $response = [];
         $endpoint = $communicationParams['url'] . '/' . $this->apiName;
         foreach ($this->getPushImportDataTypes() as $type) {
-            $params['type'] = $type;
+            $params['type'] = strtolower($type);
             $response       = array_merge_recursive($response, $this->apiClient->sendRequest($endpoint, $params));
         }
 

--- a/src/Settings/ExportSettings.php
+++ b/src/Settings/ExportSettings.php
@@ -68,7 +68,7 @@ class ExportSettings extends AbstractSection implements SectionInterface
                 'options'  => [
                     'id'    => 0,
                     'name'  => 0,
-                    'query' => [['Data'], ['Suggest']],
+                    'query' => [['Data'], ['Suggest'], ['Recommendation']],
                 ],
             ],
 


### PR DESCRIPTION
- Description:
Added Recommendation import push type. User is now allowed to choose which import type should be triggered after uploading feed.
- Tested with Oxid EShop editions/versions:
 1.7.6.1
- Tested with PHP versions:
7.1